### PR TITLE
Fix plink configuration option.

### DIFF
--- a/configure
+++ b/configure
@@ -1253,7 +1253,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-plink          Enable plink, default no.
+  --enable-plink          Enable plink, default auto.
 
 Report bugs to the package provider.
 _ACEOF
@@ -1779,24 +1779,31 @@ else
   HAS_PLINK="T"
 fi
 
-ENABLE_PLINK=FASLE
 # Check whether --enable-plink was given.
 if test "${enable_plink+set}" = set; then :
-  enableval=$enable_plink; ENABLE_PLINK=TRUE
+  enableval=$enable_plink; ENABLE_PLINK=$enableval
 else
-  ENABLE_PLINK=FALSE
+  ENABLE_PLINK=auto
 fi
 
 
 SYS_NAME=`${R_SCMD} "source('./R/get_conf.r');get.conf('SYS_NAME')"`
 OS_TYPE=`${R_SCMD} "source('./R/get_conf.r');get.conf('OS_TYPE')"`
 
-BUILD_BIN=""
 if test "X${HAS_SSH}" = "XF" -a "X${HAS_PLINK}" = "XF"; then
-  BUILD_BIN="plink"
+  NEED_PLINK=yes
 fi
-if test "X${ENABLE_PLINK}" = "XTRUE"; then
+BUILD_BIN=""
+if test "x${ENABLE_PLINK}" = "xauto"; then
+  if test "x${NEED_PLINK}" = "xyes"; then
+    BUILD_BIN="plink"
+  fi
+elif test "x${ENABLE_PLINK}" = "xyes"; then
   BUILD_BIN="plink"
+else
+  if test "x${NEED_PLINK}" = "xyes"; then
+    as_fn_error $? "Unable to find ssh or plink, but internal plink is disabled." "$LINENO" 5
+  fi
 fi
 
 echo " "

--- a/configure.ac
+++ b/configure.ac
@@ -26,22 +26,29 @@ else
 fi
 
 dnl All AC_ARG_ENABLE
-ENABLE_PLINK=FASLE
 AC_ARG_ENABLE(plink,
-  AC_HELP_STRING([--enable-plink], [Enable plink, default no.]),
-                 [ENABLE_PLINK=TRUE], [ENABLE_PLINK=FALSE])
+  AC_HELP_STRING([--enable-plink], [Enable plink, default auto.]),
+                 [ENABLE_PLINK=$enableval], [ENABLE_PLINK=auto])
 
 dnl Get build_bin
 SYS_NAME=`${R_SCMD} "source('./R/get_conf.r');get.conf('SYS_NAME')"`
 OS_TYPE=`${R_SCMD} "source('./R/get_conf.r');get.conf('OS_TYPE')"`
 
 dnl Check each condition
-BUILD_BIN=""
 if test "X${HAS_SSH}" = "XF" -a "X${HAS_PLINK}" = "XF"; then
-  BUILD_BIN="plink"
+  NEED_PLINK=yes
 fi
-if test "X${ENABLE_PLINK}" = "XTRUE"; then
+BUILD_BIN=""
+if test "x${ENABLE_PLINK}" = "xauto"; then
+  if test "x${NEED_PLINK}" = "xyes"; then
+    BUILD_BIN="plink"
+  fi
+elif test "x${ENABLE_PLINK}" = "xyes"; then
   BUILD_BIN="plink"
+else
+  if test "x${NEED_PLINK}" = "xyes"; then
+    AC_MSG_ERROR([Unable to find ssh or plink, but internal plink is disabled.])
+  fi
 fi
 
 dnl Report


### PR DESCRIPTION
The third argument to `AC_ARG_ENABLE` is what to do if the argument is specified and the fourth argument is what to do if the argument is not specified. They are not true/false handlers.

Also, error out if neither ssh nor plink is available and the internal plink was disabled.

Fixes #6.